### PR TITLE
Throw different error if accessing the preferences file is forbidden

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 const path = require('path');
 const pify = require('pify');
 const userHome = require('user-home');
-const pathExists = require('path-exists');
 const bplistParser = require('bplist-parser');
 const untildify = require('untildify');
 
@@ -10,13 +9,18 @@ const bplist = pify(bplistParser);
 const settings = path.join(userHome, '/Library/Preferences/com.runningwithcrayons.Alfred-Preferences-3.plist');
 
 module.exports = async () => {
-	const exists = await pathExists(settings);
+	let data;
 
-	if (!exists) {
-		throw new Error(`Alfred preferences not found at location ${settings}`);
+	try {
+		data = await bplist.parseFile(settings);
+	} catch (error) {
+		if (error.code === 'ENOENT') {
+			throw new Error(`Alfred preferences not found at location ${settings}`);
+		}
+
+		throw error;
 	}
 
-	const data = await bplist.parseFile(settings);
 	const syncfolder = data[0].syncfolder || '~/Library/Application Support/Alfred 3';
 
 	return untildify(`${syncfolder}/Alfred.alfredpreferences`);

--- a/index.js
+++ b/index.js
@@ -14,6 +14,10 @@ module.exports = async () => {
 	try {
 		data = await bplist.parseFile(settings);
 	} catch (error) {
+		if (error.code === 'EACCES') {
+			throw new Error(`Permission denied to read Alfred preferences at location ${settings}`);
+		}
+
 		if (error.code === 'ENOENT') {
 			throw new Error(`Alfred preferences not found at location ${settings}`);
 		}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
 	],
 	"dependencies": {
 		"bplist-parser": "^0.1.1",
-		"path-exists": "^3.0.0",
 		"pify": "^2.3.0",
 		"untildify": "^3.0.2",
 		"user-home": "^2.0.0"

--- a/test/test.js
+++ b/test/test.js
@@ -9,16 +9,24 @@ import resolveAlfredPrefs from '..';
 const settings = path.join(userHome, '/Library/Preferences/com.runningwithcrayons.Alfred-Preferences-3.plist');
 
 const mv = (src, dest) => pify(fs.rename)(src, dest).catch(() => { });
+const rm = file => pify(fs.unlink)(file);
 
 test.before(async () => {
 	await mv(settings, `${settings}.back`);
-	await cp(path.join(__dirname, 'fixtures/com.runningwithcrayons.Alfred-Preferences-3.plist'), settings);
 });
 
 test.after(async () => {
 	await mv(`${settings}.back`, settings);
 });
 
-test('resolves `Alfred.alfredpreferences` path', async t => {
+test.serial('resolves `Alfred.alfredpreferences` path', async t => {
+	await cp(path.join(__dirname, 'fixtures/com.runningwithcrayons.Alfred-Preferences-3.plist'), settings);
+
 	t.is(await resolveAlfredPrefs(), path.join(userHome, 'Documents/alfred/Alfred.alfredpreferences'));
+
+	await rm(settings);
+});
+
+test.serial('throws an error if the preferences file does not exist', async t => {
+	await t.throwsAsync(resolveAlfredPrefs, /Alfred preferences not found at location/);
 });


### PR DESCRIPTION
[If npm is invoked with root privileges, it will run lifecycle scripts as `nobody` by default](https://docs.npmjs.com/misc/scripts#user). Since `nobody` doesn’t have access to the Alfred preferences, resolve-alfred-prefs throws an “Alfred preferences not found” error.

This pull request changes the logic to distinguish between `EACCES` (permission denied) and `ENOENT` (no such file or directory) to make it more clear why resolve-alfred-prefs could not read the Alfred preferences file. Secondarily, this pull request also adds a test for if the preferences file does not exist and refactors the error handling to remove the need for [path-exists](https://github.com/sindresorhus/path-exists).

I’ll leave it up to you as to whether this qualifies as taking care of #2 or if we should specifically check for the `nobody` user, for example. In any case, I think this change makes the error message less confusing.

Fixes #2